### PR TITLE
add dotenv dependency to use .env file in bot script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/react": "18.2.21",
         "@types/react-dom": "18.2.7",
         "autoprefixer": "10.4.15",
+        "dotenv": "^16.4.5",
         "eslint": "8.47.0",
         "eslint-config-next": "13.4.19",
         "jsonwebtoken": "^9.0.2",
@@ -7732,6 +7733,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexify": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
     "autoprefixer": "10.4.15",
+    "dotenv": "^16.4.5",
     "eslint": "8.47.0",
     "eslint-config-next": "13.4.19",
     "jsonwebtoken": "^9.0.2",

--- a/scripts/bot.ts
+++ b/scripts/bot.ts
@@ -1,6 +1,7 @@
 const { Telegraf } = require("telegraf");
 const jwt = require("jsonwebtoken");
 const nodeCrypto = require("crypto");
+require('dotenv').config();
 
 // Environment variables
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN;


### PR DESCRIPTION
the bot script doesn't have access to the .env file (since it sits outside of next), so adding a dep on `dotenv` to allow it to access this file.